### PR TITLE
Add JSON export for Glance custom-api widgets

### DIFF
--- a/.github/workflows/update-graph.yml
+++ b/.github/workflows/update-graph.yml
@@ -1,4 +1,4 @@
-name: Update Letterboxd Graph
+name: Update Letterboxd Graph + JSON Export
 
 # ╔════════════════════════════════════════════════════════════════╗
 # ║  CONFIGURATION - Edit these values for your Letterboxd profile ║
@@ -89,7 +89,7 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           
-          # Add all generated files
+          # Add all generated files (dark/light SVG + letterboxd-data.json)
           git add images/
           
           # Check if there are changes

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 | 🎯 **Streak Highlighting** | Hover over "Day Streak" to highlight your longest streak |
 | 💬 **Interactive Tooltips** | Hover over cells to see film details (in browser) |
 | ⭐ **Rating Mode** | Color cells by average rating instead of watch count |
+| 📦 **JSON Export** | Writes `images/letterboxd-data.json` for external widgets (e.g. Glance `custom-api`) |
 | 🔄 **Daily Updates** | Automated updates via GitHub Actions |
 
 ---
@@ -221,6 +222,47 @@ You can customize the graph directly in the workflow file by editing the `env` s
 
 ---
 
+
+### Glance Widgets (custom-api)
+
+The generator also writes `images/letterboxd-data.json`, so you can build Glance widgets without running an extra backend container.
+
+Raw URL format:
+
+```
+https://raw.githubusercontent.com/<github-user>/letterboxd-graph/main/images/letterboxd-data.json
+```
+
+Example payload shape:
+
+```json
+{
+  "user": "nichtlegacy",
+  "year": 2026,
+  "stats": { "films": 123, "daysActive": 80, "streak": 7 },
+  "cells": [
+    {
+      "date": "2026-02-16",
+      "count": 2,
+      "ratingAvg": 3.5,
+      "films": [
+        { "title": "Film A", "year": "2024", "rating": 3.5, "url": "https://letterboxd.com/..." }
+      ],
+      "url": "https://letterboxd.com/<user>/films/diary/for/2026/02/16/"
+    }
+  ],
+  "recent": [
+    { "date": "2026-02-16", "title": "Film A", "year": "2024", "rating": 3.5, "url": "https://letterboxd.com/..." }
+  ]
+}
+```
+
+You can use this to build:
+
+- a compact heatmap widget (GitHub-like)
+- a separate stats widget (`films`, `daysActive`, `streak`)
+- an optional recent-watches list
+
 ## 📂 Project Structure
 
 ```
@@ -236,7 +278,8 @@ letterboxd-graph/
 │   └── Inter-SemiBold.ttf    # Primary font for text measurement
 ├── images/
 │   ├── github-letterboxd-dark.svg    # Generated dark theme
-│   └── github-letterboxd-light.svg   # Generated light theme
+│   ├── github-letterboxd-light.svg   # Generated light theme
+│   └── letterboxd-data.json          # Generated JSON data for widgets
 ├── src/
 │   ├── cli.js                # CLI entry point
 │   ├── fetcher.js            # Letterboxd data fetching

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'url';
 import { fetchProfileData, tryFetchMultipleYears, fetchSpecificYears, imageToBase64, closeBrowser } from './fetcher.js';
 import { generateSvg, generateMultiYearSvg } from './generator.js';
 import { svgToPng } from './exporter.js';
+import { buildJsonExport } from './stats.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -86,6 +87,7 @@ async function main() {
 
     const outputPathDark = `${outputBasePath}-dark.svg`;
     const outputPathLight = `${outputBasePath}-light.svg`;
+    const outputJsonPath = path.join(path.dirname(outputBasePath), 'letterboxd-data.json');
 
     console.log(`\n🎬 Letterboxd Contribution Graph Generator\n`);
     console.log(`Username: ${username}`);
@@ -94,7 +96,7 @@ async function main() {
     console.log(`Mode: ${mode}`);
     console.log(`Gradient: ${usernameGradient ? '✓' : '✗'}`);
     console.log(`PNG Export: ${exportPng ? '✓' : '✗'}`);
-    console.log(`Output: ${outputPathDark}, ${outputPathLight}\n`);
+    console.log(`Output: ${outputPathDark}, ${outputPathLight}, ${outputJsonPath}\n`);
 
     // Fetch profile data
     console.log("📋 Fetching profile data...");
@@ -165,8 +167,19 @@ async function main() {
     // Write SVG files
     fs.writeFileSync(outputPathDark, svgDark);
     fs.writeFileSync(outputPathLight, svgLight);
+
+    // Write JSON export for Glance custom-api and other consumers
+    const jsonExport = buildJsonExport(filmEntries, {
+      username,
+      year: years.length === 1 ? years[0] : null,
+      years,
+      recentLimit: 10
+    });
+    fs.writeFileSync(outputJsonPath, JSON.stringify(jsonExport, null, 2));
+
     console.log(`   ✓ ${outputPathDark}`);
     console.log(`   ✓ ${outputPathLight}`);
+    console.log(`   ✓ ${outputJsonPath}`);
 
     // Export PNGs if requested
     if (exportPng) {


### PR DESCRIPTION
### Motivation
- Provide a compact, consumable JSON export alongside the existing SVG outputs so external widgets (e.g. Glance `custom-api`) can read activity/stats without running a separate backend. 
- Make it easy to embed daily-run workflow output as a raw JSON URL for small dashboard widgets and recent-watches lists.

### Description
- Add `buildJsonExport(entries, options)` in `src/stats.js` which produces a widget-friendly payload containing `user`, `year`, `years`, `generatedAt`, `stats` (`films`, `daysActive`, `streak`), `cells` (per-day `date`, `count`, `ratingAvg`, `films`, `url`) and `recent` entries. 
- Update `src/cli.js` to write `images/letterboxd-data.json` alongside the existing `*-dark.svg` and `*-light.svg` outputs using the new `buildJsonExport` helper. 
- Update `README.md` to document the JSON export, show the raw GitHub `raw.githubusercontent.com/.../images/letterboxd-data.json` URL pattern, and include an example payload and widget use-cases. 
- Tweak `.github/workflows/update-graph.yml` text/comments to mention the combined SVG+JSON export and clarify generated files are added by the workflow. 

### Testing
- Ran syntax checks: `node --check src/cli.js` and `node --check src/stats.js`, both succeeded. 
- Performed a runtime smoke test invoking the exporter: `node --input-type=module -e "import { buildJsonExport } from './src/stats.js'; const data=buildJsonExport([{date:new Date('2026-02-16T00:00:00Z'),title:'Film A',year:'2024',rating:3.5,url:'https://letterboxd.com/film/a/'}],{username:'nichtlegacy',year:2026,years:[2026]}); console.log(data.user, data.stats.films, data.cells[0].count, data.recent.length);"` which printed the expected values. 
- Confirmed modified files exist and the CLI now writes `images/letterboxd-data.json` when run; automated tests above passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994886abff8832e9357383327351291)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new derived JSON artifact written by the CLI and documented in README, without changing fetching or SVG generation logic.
> 
> **Overview**
> Adds a new JSON export (`images/letterboxd-data.json`) generated from diary entries, including per-day cells, aggregate stats, and a recent-watches list via new `buildJsonExport()`.
> 
> Updates the CLI to always write this JSON next to the dark/light SVGs, and updates the workflow/README to reflect the additional generated artifact and how to consume it (e.g. via a raw GitHub URL for Glance `custom-api`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfaabc5440d3c35ecfaf621606278ea833df4c08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->